### PR TITLE
Add vote thresholds

### DIFF
--- a/Framework/PlayerStates.cs
+++ b/Framework/PlayerStates.cs
@@ -436,7 +436,7 @@ namespace ItsStardewTime.Framework
                         (
                             Game1.getFarmer(playerId).Name,
                             voted_yes,
-                            _playerStates.Count
+                            Math.Ceiling(_config.VoteThreshold * _playerStates.Count)
                         ),
                         Messages.VoteUpdateMessage,
                         new[] { _manifest.UniqueID }
@@ -449,7 +449,7 @@ namespace ItsStardewTime.Framework
                             (
                                 Game1.getFarmer(playerId).Name,
                                 voted_yes,
-                                _playerStates.Count
+                                Math.Ceiling(_config.VoteThreshold * _playerStates.Count)
                             )
                         );
                     }
@@ -462,7 +462,7 @@ namespace ItsStardewTime.Framework
                         (
                             Game1.getFarmer(playerId).Name,
                             voted_yes,
-                            _playerStates.Count
+                            Math.Ceiling(_config.VoteThreshold * _playerStates.Count)
                         ),
                         Messages.VoteUpdateMessage,
                         new[] { _manifest.UniqueID }
@@ -475,7 +475,7 @@ namespace ItsStardewTime.Framework
                             (
                                 Game1.getFarmer(playerId).Name,
                                 voted_yes,
-                                _playerStates.Count
+                                Math.Ceiling(_config.VoteThreshold * _playerStates.Count)
                             )
                         );
                     }
@@ -661,6 +661,8 @@ namespace ItsStardewTime.Framework
             bool majority_pause = PauseMode.Majority == _config.PauseMode;
             int pause_requested_count = 0;
             int pause_not_requested_count = 0;
+            int pause_voted_count = 0;
+            int pause_not_voted_count = 0;
             int min = int.MaxValue;
             PlayerState? min_player_state = null;
             foreach (var player_state in _playerStates.Values)
@@ -678,9 +680,14 @@ namespace ItsStardewTime.Framework
                     auto_freeze = AutoFreezeReason.FrozenForLocation;
                 }
 
-                if (!player_state.IsVoteForPauseAffirmative)
+                bool player_voted_pause = player_state.IsVoteForPauseAffirmative;
+                if (player_voted_pause)
                 {
-                    pause_vote_succeeded = false;
+                    pause_voted_count += 1;
+                }
+                else
+                {
+                    pause_not_voted_count += 1;
                 }
 
                 if (player_state.IsEventActive)
@@ -707,6 +714,8 @@ namespace ItsStardewTime.Framework
                     }
                 }
             }
+
+            pause_vote_succeeded = pause_voted_count >= Math.Ceiling(_config.VoteThreshold * _playerStates.Count);
 
             if (_freezeOverride != null)
             {

--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -45,6 +45,7 @@ namespace ItsStardewTime
         public bool AnyCutscenePauses = true;
         public bool LockMonsters = true;
         public bool EnableVotePause = true;
+        public double VoteThreshold = 1.0;
         public TimeSpeedMode TimeSpeedMode = TimeSpeedMode.Average;
         public bool RelativeTimeSpeed = true;
 

--- a/TimeMaster.cs
+++ b/TimeMaster.cs
@@ -689,7 +689,7 @@ namespace ItsStardewTime
                         Where(mode => !Enum.Parse<PauseMode>(mode).IsDeprecated()).
                         ToArray(),
                     formatAllowedValue: (s) => Helper.Translation.Get
-                        ($"TimeController.Config.multiplayer-host-pause-mode.{s}")
+                        ($"config.multiplayer-host-pause-mode.{s}")
                 );
                 config_menu.AddBoolOption
                 (
@@ -740,7 +740,7 @@ namespace ItsStardewTime
                         Where(mode => !Enum.Parse<TimeSpeedMode>(mode).IsDeprecated()).
                         ToArray(),
                     formatAllowedValue: (s) => Helper.Translation.Get
-                        ($"TimeController.Config.multiplayer-host-time-speed-mode.{s}")
+                        ($"config.multiplayer-host-time-speed-mode.{s}")
                 );
                 config_menu.AddBoolOption
                 (

--- a/TimeMaster.cs
+++ b/TimeMaster.cs
@@ -715,6 +715,17 @@ namespace ItsStardewTime
                     getValue: () => TimeController.Config.EnableVotePause,
                     setValue: value => TimeController.Config.EnableVotePause = value
                 );
+                config_menu.AddNumberOption
+                (
+                    mod: ModManifest,
+                    name: I18n.Config_MultiplayerHostVoteThreshold_Name,
+                    tooltip: I18n.Config_MultiplayerHostVoteThreshold_Desc,
+                    getValue: () => (float)TimeController.Config.VoteThreshold,
+                    setValue: value => TimeController.Config.VoteThreshold = value,
+                    formatValue: value => value.ToString("P0"),
+                    min: 0,
+                    max: 1
+                );
                 config_menu.AddTextOption
                 (
                     mod: ModManifest,

--- a/i18n/default.json
+++ b/i18n/default.json
@@ -63,7 +63,7 @@
     "config.additional-location-speed.desc": "This value is the speed of time while in the '{{locationName}}' location. The value is a percentage of the unmodified speed of time.",
     "config.additional-location-speed-delete.name": "Remove {{locationName}}",
     "config.additional-location-speed-delete.desc": "Remove this entry from Additional Locations.",
-    
+
     "config.additional-locations-speed.names.Name": "Additional Locations",
     "config.additional-locations-speed.names.desc": "Here you can specify names of specific locations in which to adjust the speed of time. Location names can be seen in the SMAPI console output when 'Time Flow Change Notifications' is enabled. You can list multiple with commas.",
     "config.additional-locations-speed.page.title": "Configure Additional Locations",
@@ -157,7 +157,9 @@ amount of pause time during the current day.",
     "config.multiplayer-host-lock-monsters.desc": "(host player only) When enabled, whenever time is paused, monsters will stop moving and health for monsters and players will lock.",
     "config.multiplayer-host-enable-vote-pause.name": "Enable Voting to Pause",
     "config.multiplayer-host-enable-vote-pause.desc": "(host player only) When enabled, players can vote to pause time. This is in addition to normal pause functionality.",
-    
+    "config.multiplayer-host-vote-threshold.name": "Voting Threshold",
+    "config.multiplayer-host-vote-threshold.desc": "This value is the threshold for votes required to pause time.",
+
     "config.multiplayer-host-time-speed-mode.name": "Time Speed Mode",
     "config.multiplayer-host-time-speed-mode.desc": "(host player only)
 If set to 'Average' mode by the multiplayer host, time will flow at a speed


### PR DESCRIPTION
Adds a new config option that allows the host to determine how many votes are required in order for a pause vote to pass.