### PR TITLE
Minor vote threshold refactor

### DIFF
--- a/Framework/PlayerStates.cs
+++ b/Framework/PlayerStates.cs
@@ -436,7 +436,7 @@ namespace ItsStardewTime.Framework
                         (
                             Game1.getFarmer(playerId).Name,
                             voted_yes,
-                            Math.Ceiling(_config.VoteThreshold * _playerStates.Count)
+                            _config.GetVoteThresholdCount(_playerStates.Count)
                         ),
                         Messages.VoteUpdateMessage,
                         new[] { _manifest.UniqueID }
@@ -449,7 +449,7 @@ namespace ItsStardewTime.Framework
                             (
                                 Game1.getFarmer(playerId).Name,
                                 voted_yes,
-                                Math.Ceiling(_config.VoteThreshold * _playerStates.Count)
+                                _config.GetVoteThresholdCount(_playerStates.Count)
                             )
                         );
                     }
@@ -462,7 +462,7 @@ namespace ItsStardewTime.Framework
                         (
                             Game1.getFarmer(playerId).Name,
                             voted_yes,
-                            Math.Ceiling(_config.VoteThreshold * _playerStates.Count)
+                            _config.GetVoteThresholdCount(_playerStates.Count)
                         ),
                         Messages.VoteUpdateMessage,
                         new[] { _manifest.UniqueID }
@@ -475,7 +475,7 @@ namespace ItsStardewTime.Framework
                             (
                                 Game1.getFarmer(playerId).Name,
                                 voted_yes,
-                                Math.Ceiling(_config.VoteThreshold * _playerStates.Count)
+                                _config.GetVoteThresholdCount(_playerStates.Count)
                             )
                         );
                     }
@@ -715,7 +715,7 @@ namespace ItsStardewTime.Framework
                 }
             }
 
-            pause_vote_succeeded = pause_voted_count >= Math.Ceiling(_config.VoteThreshold * _playerStates.Count);
+            pause_vote_succeeded = pause_voted_count >= _config.GetVoteThresholdCount(_playerStates.Count);
 
             if (_freezeOverride != null)
             {

--- a/ModConfig.cs
+++ b/ModConfig.cs
@@ -45,7 +45,13 @@ namespace ItsStardewTime
         public bool AnyCutscenePauses = true;
         public bool LockMonsters = true;
         public bool EnableVotePause = true;
-        public double VoteThreshold = 1.0;
+
+        public double VoteThresholdPercent
+        {
+            get;
+            set;
+        } = 1.0;
+        
         public TimeSpeedMode TimeSpeedMode = TimeSpeedMode.Average;
         public bool RelativeTimeSpeed = true;
 
@@ -117,6 +123,8 @@ namespace ItsStardewTime
                 field.SetValue(this, field.GetValue(other));
             }
         }
+
+        public double GetVoteThresholdCount(int playerCount) => Math.Ceiling(VoteThresholdPercent * playerCount);
 
         /*********
          ** Private methods

--- a/TimeMaster.cs
+++ b/TimeMaster.cs
@@ -720,8 +720,8 @@ namespace ItsStardewTime
                     mod: ModManifest,
                     name: I18n.Config_MultiplayerHostVoteThreshold_Name,
                     tooltip: I18n.Config_MultiplayerHostVoteThreshold_Desc,
-                    getValue: () => (float)TimeController.Config.VoteThreshold,
-                    setValue: value => TimeController.Config.VoteThreshold = value,
+                    getValue: () => (float)TimeController.Config.VoteThresholdPercent,
+                    setValue: value => TimeController.Config.VoteThresholdPercent = value,
                     formatValue: value => value.ToString("P0"),
                     min: 0,
                     max: 1


### PR DESCRIPTION
Simple change to the new vote threshold feature. Motivation: minor style and maintainability improvement. If for whatever reason there's ever a need to change how the threshold count is calculated, it's better to have that calculation happen in one place (a method) rather than having to track down each place we calculate it. It also makes it more clear to anybody reading the code in the future what the code is trying to do.